### PR TITLE
Add secret fields to Spec

### DIFF
--- a/pkg/apis/pockost.com/v1beta1/types.go
+++ b/pkg/apis/pockost.com/v1beta1/types.go
@@ -20,6 +20,8 @@ type SshPipe struct {
 type SshPipeSpec struct {
 	Users  []string   `json:"users"`
 	Target TargetSpec `json:"target"`
+	AuthorizedKeys  string   `json:"authorizedKeys"`
+	PrivateKey string `json:"privateKey"`
 }
 type TargetSpec struct {
 	Name string `json:"name"`


### PR DESCRIPTION
This allows setting Kubernetes Secret names of resources living
in same namespace of SshPipe providing keyring for sshpiper.