### PR TITLE
Allow spec of target namespace

### DIFF
--- a/pkg/apis/pockost.com/v1beta1/types.go
+++ b/pkg/apis/pockost.com/v1beta1/types.go
@@ -27,6 +27,7 @@ type TargetSpec struct {
 	Name string `json:"name"`
 	Port int    `json:"port"`
 	User string `json:"user"`
+	Namespace string `json:"namespace"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
The SshPipe resource might be deployed in a diff namespace than the
actual target service.
